### PR TITLE
🌠 Config image format

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,11 @@ Configuration files must be places inside image in folder `/code/`.
       "height": 200,
       "life_time_days": 30,
       "source_bucket": null,
-      "alias": null
+      "alias": null,
+      "format": "jpeg",
+      "format_args": {
+        "optimize": true
+      }
     }
   },
   "source_bucket": "images",
@@ -155,6 +159,23 @@ The rest parameters have the same meaning as it described in S3 configs section.
 * `source_bucket` - overrides root `source_bucket`, so you can define thumbnail buckets for few buckets with original
   files. If this config is not set - the root `source_bucket` will be used.
 * `alias` - an optional alias for the bucket, used for alternative endpoint (see below).
+* `format` - thumbnail file format, available options:
+  * `jpeg` - JPEG file
+  * `png` - PNG file
+  * `none` - keep source file format
+* `format_args` - optional arguments for file format, see description below.
+
+ℹ️ Description about `format_args`:
+
+Mostly you don't want to set these args because it can lead to unpredictable result like corrupted images, but if you
+want to, you can set any settings according to the PIL documentation:
+* for `jpeg`: https://pillow.readthedocs.io/en/stable/handbook/image-file-formats.html#jpeg-saving
+* for `png`: https://pillow.readthedocs.io/en/stable/handbook/image-file-formats.html#png-saving
+
+Unknown arguments are ignored. If not set, following arguments applied:
+```json
+{ "optimize": true }
+```
 
 The bucket config can set as string value in http query-like way, for example:
 

--- a/config.json
+++ b/config.json
@@ -5,7 +5,8 @@
         "w": 300,
         "h": 300
       },
-      "alias": "small"
+      "alias": "small",
+      "format": "jpeg"
     },
     "thumbnail-medium": {
       "size": "500x500",

--- a/playground/docker-compose.yaml
+++ b/playground/docker-compose.yaml
@@ -44,6 +44,7 @@ services:
     environment:
       BUCKETS__THUMBNAIL-SMALL__SIZE: "100x100"
       BUCKETS__THUMBNAIL-SMALL__ALIAS: small
+      BUCKETS__THUMBNAIL-SMALL__FORMAT: "JPEG"
       BUCKETS__THUMBNAIL-MEDIUM__SIZE: "500x500"
       BUCKETS__THUMBNAIL-MEDIUM__ALIAS: medium
       S3: "http://MINIO_AK:MINIO_SK@minio:9000/eu-west-1/images"

--- a/src/sts/config.py
+++ b/src/sts/config.py
@@ -5,6 +5,8 @@ from pydantic import BaseModel, HttpUrl, model_validator, Field
 from pydantic.dataclasses import dataclass
 from pydantic_settings import BaseSettings, SettingsConfigDict, PydanticBaseSettingsSource, JsonConfigSettingsSource
 
+from sts.models import ImageFormat
+
 
 @dataclass(frozen=True, slots=True)
 class ImageSize:
@@ -27,6 +29,12 @@ class BucketSettings(BaseModel):
 
     alias: str | None = None
     """ Optional alias for the bucket, can be used for alternative routes """
+
+    format: ImageFormat = ImageFormat.NONE
+    """ Image format, available values: NONE (default), JPEG, PNG """
+
+    format_args: dict[str, typing.Any] | None = None
+    """ Additional format parameters, None by default """
 
 
 @dataclass(frozen=True, slots=True)

--- a/src/sts/images/image_processor.py
+++ b/src/sts/images/image_processor.py
@@ -57,13 +57,14 @@ def resize_image(data: BytesIO,
         try:
             with Image.open(data) as im:
                 mime_type = im.get_format_mimetype()
-
                 new_size: tuple[float, float] = (float(width), float(height))
                 im.thumbnail(new_size)
 
                 if image_format != ImageFormat.NONE:
                     dest_mode = _format_modes[image_format]
                     im = _try_convert_image(im, dest_mode).image
+                    im.format = str(image_format)
+                    mime_type = Image.MIME.get(im.format.upper())
 
                 result = BytesIO()
                 im.save(result, im.format, **save_params)

--- a/src/sts/images/models.py
+++ b/src/sts/images/models.py
@@ -1,7 +1,6 @@
 from dataclasses import dataclass
 from io import BytesIO
 
-
 @dataclass(frozen=True, slots=True)
 class ImageData:
     content_type: str

--- a/src/sts/images/thumbnail_service.py
+++ b/src/sts/images/thumbnail_service.py
@@ -75,7 +75,9 @@ class ThumbnailService:
             return NOT_FOUND_RESPONSE
 
         self._logger.debug("Source file was loaded into memory")
-        thumbnail = resize_image(image_data, bucket_settings.size.w, bucket_settings.size.h)
+        thumbnail = resize_image(image_data,
+                                 bucket_settings.size.w, bucket_settings.size.h,
+                                 bucket_settings.format, bucket_settings.format_args)
         if thumbnail.error or not thumbnail.data:
             self._logger.warning(f"Failed to create thumbnail: {thumbnail.error}")
             return NOT_FOUND_RESPONSE

--- a/src/sts/models.py
+++ b/src/sts/models.py
@@ -1,6 +1,10 @@
 import enum
 from dataclasses import dataclass
 
+class ImageFormat(enum.StrEnum):
+    NONE = enum.auto()
+    PNG = enum.auto()
+    JPEG = enum.auto()
 
 class BucketStatus(str, enum.Enum):
     created = "created",

--- a/tests/app_settings_test.py
+++ b/tests/app_settings_test.py
@@ -1,4 +1,5 @@
 from sts.config import get_app_settings, get_buckets_map, ImageSize, BucketSettings
+from sts.models import ImageFormat
 
 
 def _assert_that_bucket_settings_are_equal(expected: BucketSettings, actual: BucketSettings):
@@ -26,7 +27,8 @@ _expected_thumbnail = BucketSettings(alias=None,
 _expected_pictures_small = BucketSettings(alias='p',
                                           size=ImageSize(50, 50),
                                           source_bucket='items',
-                                          life_time_days=30)
+                                          life_time_days=30,
+                                          format=ImageFormat.JPEG)
 
 
 def test_read():
@@ -91,6 +93,7 @@ def test_buckets_map():
     # assert thumbnail
     bucket_settings = buckets_map.buckets['thumbnail']
     _assert_that_bucket_settings_are_equal(_expected_thumbnail, bucket_settings)
+
 
 def test_uvicorn_defaults():
     # arrange & act

--- a/tests/config.json
+++ b/tests/config.json
@@ -15,7 +15,7 @@
     "thumbnail": {
       "life_time_days": 10
     },
-    "pictures-small": "alias=p&size=50x50&source_bucket=items"
+    "pictures-small": "alias=p&size=50x50&source_bucket=items&format=jpeg"
   },
   "s3": "http://MINIO_AK:MINIO_SK@localhost:9000/eu-west-1/images",
   "size": "100x100",

--- a/tests/image_processor_test.py
+++ b/tests/image_processor_test.py
@@ -2,22 +2,38 @@ from io import BytesIO
 from PIL import Image
 
 from sts.images.image_processor import resize_image
+from sts.models import ImageFormat
 
 
 def __read_file(file_name: str) -> BytesIO:
-    with open(file_name, "rb") as file_data:
+    with open(file_name, 'rb') as file_data:
         return BytesIO(file_data.read())
 
 
 def test_resize_image() -> None:
-    file_data = __read_file("test.png")
+    file_data = __read_file('test.png')
     resize_result = resize_image(file_data, 100, 100)
 
     assert not resize_result.error
-    assert resize_result.content_type == "image/png"
+    assert resize_result.content_type == 'image/png'
     assert resize_result.data
 
     with resize_result.data:
         with Image.open(resize_result.data) as image:
             assert image.size[0] == 100
             assert image.size[1] == 100
+
+def test_resize_image_png2jpeg() -> None:
+    file_data = __read_file('test.png')
+    resize_result = resize_image(file_data, 100, 100, image_format=ImageFormat.JPEG)
+    
+    assert not resize_result.error
+    assert resize_result.content_type == 'image/jpeg'
+    assert resize_result.data
+
+    with resize_result.data:
+        with Image.open(resize_result.data) as image:
+            assert image.size[0] == 100
+            assert image.size[1] == 100
+            assert image.mode == 'RGB'
+            assert image.get_format_mimetype() == 'image/jpeg'

--- a/tests/image_processor_test.py
+++ b/tests/image_processor_test.py
@@ -5,6 +5,11 @@ from sts.images.image_processor import resize_image
 from sts.models import ImageFormat
 
 
+_mime_png = 'image/png'
+_mime_jpeg = 'image/jpeg'
+_mode_rgb = 'RGB'
+_format_png = 'PNG'
+
 def __read_file(file_name: str) -> BytesIO:
     with open(file_name, 'rb') as file_data:
         return BytesIO(file_data.read())
@@ -15,25 +20,27 @@ def test_resize_image() -> None:
     resize_result = resize_image(file_data, 100, 100)
 
     assert not resize_result.error
-    assert resize_result.content_type == 'image/png'
+    assert resize_result.content_type == _mime_png
     assert resize_result.data
 
     with resize_result.data:
         with Image.open(resize_result.data) as image:
             assert image.size[0] == 100
             assert image.size[1] == 100
+            assert image.format == _format_png
+
 
 def test_resize_image_png2jpeg() -> None:
     file_data = __read_file('test.png')
     resize_result = resize_image(file_data, 100, 100, image_format=ImageFormat.JPEG)
-    
+
     assert not resize_result.error
-    assert resize_result.content_type == 'image/jpeg'
+    assert resize_result.content_type == _mime_jpeg
     assert resize_result.data
 
     with resize_result.data:
         with Image.open(resize_result.data) as image:
             assert image.size[0] == 100
             assert image.size[1] == 100
-            assert image.mode == 'RGB'
-            assert image.get_format_mimetype() == 'image/jpeg'
+            assert image.mode == _mode_rgb
+            assert image.get_format_mimetype() == _mime_jpeg


### PR DESCRIPTION
This PR adds new config to bucket section:
* file format - you can pick thumbnail file format `PNG` or `JPEG`; use `NONE` to keep the same format as the source image
* format arguments - additional optional set of configuration for the selected file format, according to the `PIL` library docuemntation